### PR TITLE
メモリリークの修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchFragment.kt
@@ -62,9 +62,7 @@ class RepositorySearchFragment : Fragment() {
             .setOnEditorActionListener { editText, action, _ ->
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
                     editText.text.toString().let {
-                        viewModel.searchResults(it).apply {
-                            adapter?.submitList(this)
-                        }
+                        viewModel.searchRepositories(it)
                     }
                     return@setOnEditorActionListener true
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
@@ -10,13 +10,10 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.data.model.RepositoryItem
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -30,21 +27,6 @@ class RepositorySearchViewModel : ViewModel() {
 
     /**
      * 与えられたキーワードをもとに検索処理を行う
-     * @param inputText 検索するキーワード
-     * @return 検索結果
-     */
-    @Deprecated("searchRepositories に置き換える予定")
-    fun searchResults(inputText: String): List<RepositoryItem> = runBlocking {
-        return@runBlocking GlobalScope.async {
-            val jsonStr = requestSearchRepositories(inputText = inputText)
-            val jsonBody = JSONObject(jsonStr)
-            val jsonItems = jsonBody.optJSONArray("items") ?: return@async emptyList()
-            return@async convertToRepositoryItems(jsonItems = jsonItems)
-        }.await()
-    }
-
-    /**
-     * 与えられたキーワードをもとに検索処理を行う（非同期版）
      * @param inputText 検索するキーワード
      * @return 検索結果
      */


### PR DESCRIPTION
## Issue
- #3

## 概要（必須）
- RepositorySearchViewModel#searchResults にて、GlobalScope を使用して非同期処理を行なっていたが、GlobalScope では GC が行われずメモリが残り続けるリスクがあるため、viewModelScope を使うようにする。
- あわせて runBlocking や async-await を使ってスレッドをブロックしつつ処理が終わるのを待つのはかなりパフォーマンスが悪いので、StateFlow を使って値を監視し、非同期で取得するように修正する。

## リンク
- https://discuss.kotlinlang.org/t/unavoidable-memory-leak-when-using-coroutines/11603

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/fafb3bc7-84a6-4e68-a357-b1901fda4ffb" width="300" > | <video src="https://github.com/user-attachments/assets/fcf06b66-b878-4fd4-8f71-804c200e2932" width="300" >
