### PR TITLE
forksCount のパースにて、キー名が typo していたため修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
@@ -54,7 +54,7 @@ class RepositorySearchViewModel : ViewModel() {
             val language = jsonItem.optString("language")
             val stargazersCount = jsonItem.optLong("stargazers_count")
             val watchersCount = jsonItem.optLong("watchers_count")
-            val forksCount = jsonItem.optLong("forks_conut")
+            val forksCount = jsonItem.optLong("forks_count")
             val openIssuesCount = jsonItem.optLong("open_issues_count")
 
             items.add(


### PR DESCRIPTION
## Issue
- #3

## 概要（必須）
- forksCount のパースにて、キー名が typo していたため修正した

## リンク
- https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-repositories

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/99ef9c42-14fe-4ada-b5d3-53a04e152cc7" width="300" /> | <img src="https://github.com/user-attachments/assets/9bc2dc64-d7b3-4a2c-8bb8-39874d3602c1" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
