### PR TITLE
API 通信周りを SearchRepository に移行

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation 'io.ktor:ktor-client-android:2.3.10'
     implementation "io.ktor:ktor-serialization-kotlinx-json:2.3.10"
     implementation "io.ktor:ktor-client-content-negotiation:2.3.10"
+    implementation "io.ktor:ktor-client-logging:2.3.10"
+
+    implementation 'org.slf4j:slf4j-android:1.7.36'
 
     implementation 'io.coil-kt:coil:1.3.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'kotlin-parcelize'
+    id 'kotlinx-serialization'
     id 'androidx.navigation.safeargs.kotlin'
     id 'com.google.dagger.hilt.android'
 }
@@ -55,7 +56,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.8.3'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
-    implementation 'io.ktor:ktor-client-android:1.6.4'
+
+    implementation 'io.ktor:ktor-client-android:2.3.10'
+    implementation "io.ktor:ktor-serialization-kotlinx-json:2.3.10"
 
     implementation 'io.coil-kt:coil:1.3.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
     implementation 'io.ktor:ktor-client-android:2.3.10'
     implementation "io.ktor:ktor-serialization-kotlinx-json:2.3.10"
+    implementation "io.ktor:ktor-client-content-negotiation:2.3.10"
 
     implementation 'io.coil-kt:coil:1.3.2'
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
@@ -6,6 +6,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import jp.co.yumemi.android.code_check.data.repository.SearchRepository
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -15,5 +16,13 @@ object ApiModule {
     @Singleton
     fun provideHttpClient(): HttpClient {
         return HttpClient(Android)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSearchRepository(
+        httpClient: HttpClient,
+    ): SearchRepository {
+        return SearchRepository(httpClient)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
@@ -6,7 +6,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import jp.co.yumemi.android.code_check.data.repository.SearchRepository
+import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -15,7 +18,15 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideHttpClient(): HttpClient {
-        return HttpClient(Android)
+        return HttpClient(Android) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                    },
+                )
+            }
+        }
     }
 
     @Provides

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/di/ApiModule.kt
@@ -7,6 +7,8 @@ import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
 import io.ktor.serialization.kotlinx.json.json
 import jp.co.yumemi.android.code_check.data.repository.SearchRepository
 import kotlinx.serialization.json.Json
@@ -25,6 +27,9 @@ object ApiModule {
                         ignoreUnknownKeys = true
                     },
                 )
+            }
+            install(Logging) {
+                level = LogLevel.ALL
             }
         }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
@@ -13,3 +13,15 @@ data class RepositoryItem(
     val forksCount: Long,
     val openIssuesCount: Long,
 ) : Parcelable
+
+fun SearchRepositoryResponse.toRepositoryItem(): RepositoryItem {
+    return RepositoryItem(
+        name = fullName,
+        ownerIconUrl = owner?.avatarUrl ?: "",
+        language = language ?: "",
+        stargazersCount = stargazersCount,
+        watchersCount = watchersCount,
+        forksCount = forksCount,
+        openIssuesCount = openIssuesCount,
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
@@ -1,0 +1,28 @@
+package jp.co.yumemi.android.code_check.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * @see <a href="https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-repositories">Search repositories</a>
+ */
+@Serializable
+data class SearchRepositoriesResponse(
+    @SerialName("items") val items: List<SearchRepositoryResponse>,
+)
+
+@Serializable
+data class SearchRepositoryResponse(
+    @SerialName("full_name") val fullName: String,
+    @SerialName("owner") val owner: Owner?,
+    @SerialName("language") val language: String?,
+    @SerialName("stargazers_count") val stargazersCount: Long,
+    @SerialName("watchers_count") val watchersCount: Long,
+    @SerialName("forks_count") val forksCount: Long,
+    @SerialName("open_issues_count") val openIssuesCount: Long,
+)
+
+@Serializable
+data class Owner(
+    @SerialName("avatar_url") val avatarUrl: String,
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
@@ -1,0 +1,4 @@
+package jp.co.yumemi.android.code_check.data.repository
+
+class SearchRepository {
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
@@ -3,7 +3,6 @@ package jp.co.yumemi.android.code_check.data.repository
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.data.model.SearchRepositoriesResponse
@@ -14,7 +13,6 @@ class SearchRepository @Inject constructor(
 ) {
     suspend fun requestSearchRepositories(inputText: String): SearchRepositoriesResponse {
         val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
             parameter("q", inputText)
         }
         return response.body<SearchRepositoriesResponse>()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
@@ -1,4 +1,21 @@
 package jp.co.yumemi.android.code_check.data.repository
 
-class SearchRepository {
+import io.ktor.client.HttpClient
+import io.ktor.client.call.receive
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
+import javax.inject.Inject
+
+class SearchRepository @Inject constructor(
+    private val client: HttpClient,
+) {
+    suspend fun requestSearchRepositories(inputText: String): String {
+        val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
+            header("Accept", "application/vnd.github.v3+json")
+            parameter("q", inputText)
+        }
+        return response.receive()
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
@@ -1,7 +1,7 @@
 package jp.co.yumemi.android.code_check.data.repository
 
 import io.ktor.client.HttpClient
-import io.ktor.client.call.receive
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -16,6 +16,6 @@ class SearchRepository @Inject constructor(
             header("Accept", "application/vnd.github.v3+json")
             parameter("q", inputText)
         }
-        return response.receive()
+        return response.body<String>()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepository.kt
@@ -6,16 +6,17 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
+import jp.co.yumemi.android.code_check.data.model.SearchRepositoriesResponse
 import javax.inject.Inject
 
 class SearchRepository @Inject constructor(
     private val client: HttpClient,
 ) {
-    suspend fun requestSearchRepositories(inputText: String): String {
+    suspend fun requestSearchRepositories(inputText: String): SearchRepositoriesResponse {
         val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
             header("Accept", "application/vnd.github.v3+json")
             parameter("q", inputText)
         }
-        return response.body<String>()
+        return response.body<SearchRepositoriesResponse>()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.json.JSONArray
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -37,32 +36,5 @@ class RepositorySearchViewModel @Inject constructor(
             Timber.e(throwable)
             _repositoryItems.value = emptyList()
         }
-    }
-
-    private fun convertToRepositoryItems(jsonItems: JSONArray): List<RepositoryItem> {
-        val items = mutableListOf<RepositoryItem>()
-        for (i in 0 until jsonItems.length()) {
-            val jsonItem = jsonItems.optJSONObject(i) ?: continue
-            val name = jsonItem.optString("full_name")
-            val ownerIconUrl = jsonItem.optJSONObject("owner")?.optString("avatar_url") ?: ""
-            val language = jsonItem.optString("language")
-            val stargazersCount = jsonItem.optLong("stargazers_count")
-            val watchersCount = jsonItem.optLong("watchers_count")
-            val forksCount = jsonItem.optLong("forks_count")
-            val openIssuesCount = jsonItem.optLong("open_issues_count")
-
-            items.add(
-                RepositoryItem(
-                    name = name,
-                    ownerIconUrl = ownerIconUrl,
-                    language = language,
-                    stargazersCount = stargazersCount,
-                    watchersCount = watchersCount,
-                    forksCount = forksCount,
-                    openIssuesCount = openIssuesCount,
-                ),
-            )
-        }
-        return items.toList()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.code_check.data.model.RepositoryItem
+import jp.co.yumemi.android.code_check.data.model.toRepositoryItem
 import jp.co.yumemi.android.code_check.data.repository.SearchRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONArray
-import org.json.JSONObject
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -31,10 +31,8 @@ class RepositorySearchViewModel @Inject constructor(
      */
     fun searchRepositories(inputText: String) = viewModelScope.launch {
         try {
-            val jsonStr = searchRepository.requestSearchRepositories(inputText = inputText)
-            val jsonBody = JSONObject(jsonStr)
-            val jsonItems = jsonBody.optJSONArray("items") ?: return@launch
-            _repositoryItems.value = convertToRepositoryItems(jsonItems = jsonItems)
+            val response = searchRepository.requestSearchRepositories(inputText = inputText)
+            _repositoryItems.value = response.items.map { it.toRepositoryItem() }
         } catch (throwable: Throwable) {
             Timber.e(throwable)
             _repositoryItems.value = emptyList()

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.3"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath "org.jetbrains.kotlin:kotlin-serialization:2.0.21"
     }
 }
 


### PR DESCRIPTION
## Issue
- #6 

## 概要（必須）
- ViewModel に記載されていた API 通信周りの処理を SearchRepository に移行し、テストを書きやすくする

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/81a3a46a-ecde-4c2b-b431-1833396f2e09" width="300" > | <video src="https://github.com/user-attachments/assets/c445fdbb-be0c-4404-8600-364f089fc7bd" width="300" >