### PR TITLE
Feature/implement custom tabs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
+    implementation("androidx.browser:browser:1.8.0")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.7")
@@ -75,7 +76,6 @@ dependencies {
 
     implementation("org.slf4j:slf4j-android:1.7.36")
 
-    implementation("io.coil-kt:coil:1.3.2")
     implementation("io.coil-kt:coil-compose:2.7.0")
 
     implementation("com.jakewharton.timber:timber:5.0.1")

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 data class RepositoryItem(
     val name: String,
     val ownerIconUrl: String,
-    val url: String,
+    val htmlUrl: String,
     val language: String?,
     val stargazersCount: Long,
     val watchersCount: Long,
@@ -19,7 +19,7 @@ data class RepositoryItem(
             return RepositoryItem(
                 name = "dtrupenn/Tetris",
                 ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                url = "https://api.github.com/repos/dtrupenn/Tetris",
+                htmlUrl = "https://api.github.com/repos/dtrupenn/Tetris",
                 language = "Assembly",
                 stargazersCount = 1,
                 watchersCount = 1,
@@ -34,7 +34,7 @@ fun SearchRepositoryResponse.toRepositoryItem(): RepositoryItem {
     return RepositoryItem(
         name = fullName,
         ownerIconUrl = owner?.avatarUrl ?: "",
-        url = url,
+        htmlUrl = htmlUrl,
         language = language,
         stargazersCount = stargazersCount,
         watchersCount = watchersCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/RepositoryItem.kt
@@ -7,17 +7,34 @@ import kotlinx.parcelize.Parcelize
 data class RepositoryItem(
     val name: String,
     val ownerIconUrl: String,
+    val url: String,
     val language: String?,
     val stargazersCount: Long,
     val watchersCount: Long,
     val forksCount: Long,
     val openIssuesCount: Long,
-) : Parcelable
+) : Parcelable {
+    companion object {
+        fun fake(): RepositoryItem {
+            return RepositoryItem(
+                name = "dtrupenn/Tetris",
+                ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+                url = "https://api.github.com/repos/dtrupenn/Tetris",
+                language = "Assembly",
+                stargazersCount = 1,
+                watchersCount = 1,
+                forksCount = 0,
+                openIssuesCount = 0,
+            )
+        }
+    }
+}
 
 fun SearchRepositoryResponse.toRepositoryItem(): RepositoryItem {
     return RepositoryItem(
         name = fullName,
         ownerIconUrl = owner?.avatarUrl ?: "",
+        url = url,
         language = language,
         stargazersCount = stargazersCount,
         watchersCount = watchersCount,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
@@ -15,7 +15,7 @@ data class SearchRepositoriesResponse(
 data class SearchRepositoryResponse(
     @SerialName("full_name") val fullName: String,
     @SerialName("owner") val owner: Owner?,
-    @SerialName("url") val url: String,
+    @SerialName("html_url") val htmlUrl: String,
     @SerialName("language") val language: String?,
     @SerialName("stargazers_count") val stargazersCount: Long,
     @SerialName("watchers_count") val watchersCount: Long,
@@ -32,7 +32,7 @@ fun SearchRepositoryResponse.Companion.fake(): SearchRepositoryResponse {
     return SearchRepositoryResponse(
         fullName = "dtrupenn/Tetris",
         owner = Owner(avatarUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"),
-        url = "https://api.github.com/repos/dtrupenn/Tetris",
+        htmlUrl = "https://api.github.com/repos/dtrupenn/Tetris",
         language = "Assembly",
         stargazersCount = 1,
         watchersCount = 1,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/model/SearchRepositoriesResponse.kt
@@ -15,6 +15,7 @@ data class SearchRepositoriesResponse(
 data class SearchRepositoryResponse(
     @SerialName("full_name") val fullName: String,
     @SerialName("owner") val owner: Owner?,
+    @SerialName("url") val url: String,
     @SerialName("language") val language: String?,
     @SerialName("stargazers_count") val stargazersCount: Long,
     @SerialName("watchers_count") val watchersCount: Long,
@@ -26,3 +27,16 @@ data class SearchRepositoryResponse(
 data class Owner(
     @SerialName("avatar_url") val avatarUrl: String,
 )
+
+fun SearchRepositoryResponse.Companion.fake(): SearchRepositoryResponse {
+    return SearchRepositoryResponse(
+        fullName = "dtrupenn/Tetris",
+        owner = Owner(avatarUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"),
+        url = "https://api.github.com/repos/dtrupenn/Tetris",
+        language = "Assembly",
+        stargazersCount = 1,
+        watchersCount = 1,
+        forksCount = 0,
+        openIssuesCount = 0,
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailFragment.kt
@@ -38,7 +38,7 @@ class RepositoryDetailFragment : Fragment() {
                         onShowDetailButtonClick = {
                             val activity = this@RepositoryDetailFragment.activity ?: return@RepositoryDetailScreen
                             val intent = CustomTabsIntent.Builder().build()
-                            intent.launchUrl(activity, Uri.parse(args.item.url))
+                            intent.launchUrl(activity, Uri.parse(args.item.htmlUrl))
                         },
                     )
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailFragment.kt
@@ -3,10 +3,12 @@
  */
 package jp.co.yumemi.android.code_check.ui.detail
 
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
@@ -32,6 +34,11 @@ class RepositoryDetailFragment : Fragment() {
                             if (!findNavController().navigateUp()) {
                                 activity?.finish()
                             }
+                        },
+                        onShowDetailButtonClick = {
+                            val activity = this@RepositoryDetailFragment.activity ?: return@RepositoryDetailScreen
+                            val intent = CustomTabsIntent.Builder().build()
+                            intent.launchUrl(activity, Uri.parse(args.item.url))
                         },
                     )
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -2,9 +2,11 @@ package jp.co.yumemi.android.code_check.ui.detail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -12,6 +14,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -29,6 +32,7 @@ fun RepositoryDetailScreen(
     item: RepositoryItem,
     onCloseButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onShowDetailButtonClick: () -> Unit,
 ) {
     Scaffold(
         modifier = modifier,
@@ -52,7 +56,8 @@ fun RepositoryDetailScreen(
         Column(
             modifier = Modifier
                 .padding(it)
-                .padding(horizontal = 8.dp),
+                .padding(horizontal = 8.dp)
+                .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             OwnerIcon(ownerIconUrl = item.ownerIconUrl)
@@ -66,6 +71,12 @@ fun RepositoryDetailScreen(
             Text(text = stringResource(R.string.watchers_count, item.watchersCount))
             Text(text = stringResource(R.string.forks_count, item.forksCount))
             Text(text = stringResource(R.string.open_issues_count, item.openIssuesCount))
+            Button(
+                onClick = onShowDetailButtonClick,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            ) {
+                Text(text = stringResource(id = R.string.show_detail_button_label))
+            }
         }
     }
 }
@@ -77,6 +88,7 @@ private fun RepositoryDetailScreenPreview() {
         RepositoryDetailScreen(
             item = RepositoryItem.fake(),
             onCloseButtonClick = {},
+            onShowDetailButtonClick = {},
         )
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -75,15 +75,7 @@ fun RepositoryDetailScreen(
 private fun RepositoryDetailScreenPreview() {
     MainTheme {
         RepositoryDetailScreen(
-            item = RepositoryItem(
-                name = "dtrupenn/Tetris",
-                ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                language = "Assembly",
-                stargazersCount = 1,
-                watchersCount = 1,
-                forksCount = 0,
-                openIssuesCount = 0,
-            ),
+            item = RepositoryItem.fake(),
             onCloseButtonClick = {},
         )
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
@@ -130,15 +130,7 @@ fun RepositorySearchScreen(
 private fun RepositorySearchScreenPreview() {
     RepositorySearchScreen(
         repositoryItems = List(10) {
-            RepositoryItem(
-                name = "dtrupenn/Tetris",
-                ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                language = "Assembly",
-                stargazersCount = 1,
-                watchersCount = 1,
-                forksCount = 0,
-                openIssuesCount = 0,
-            )
+            RepositoryItem.fake()
         },
         onSearchButtonClick = {},
         onItemClick = {},

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.data.model.RepositoryItem
 import jp.co.yumemi.android.code_check.ui.common.OwnerIcon
+import jp.co.yumemi.android.code_check.ui.theme.MainTheme
 
 @Composable
 fun RepositorySearchScreen(
@@ -128,11 +129,13 @@ fun RepositorySearchScreen(
 @Preview
 @Composable
 private fun RepositorySearchScreenPreview() {
-    RepositorySearchScreen(
-        repositoryItems = List(10) {
-            RepositoryItem.fake()
-        },
-        onSearchButtonClick = {},
-        onItemClick = {},
-    )
+    MainTheme {
+        RepositorySearchScreen(
+            repositoryItems = List(10) {
+                RepositoryItem.fake()
+            },
+            onSearchButtonClick = {},
+            onItemClick = {},
+        )
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="watchers_count">%d watchers</string>
     <string name="forks_count">%d forks</string>
     <string name="open_issues_count">%d open issues</string>
+    <string name="show_detail_button_label">Show Detail</string>
 </resources>

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepositoryTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepositoryTest.kt
@@ -9,9 +9,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
-import jp.co.yumemi.android.code_check.data.model.Owner
 import jp.co.yumemi.android.code_check.data.model.SearchRepositoriesResponse
 import jp.co.yumemi.android.code_check.data.model.SearchRepositoryResponse
+import jp.co.yumemi.android.code_check.data.model.fake
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.runner.RunWith
@@ -45,15 +45,7 @@ class SearchRepositoryTest {
         val repository = SearchRepository(client = client)
         val expected = SearchRepositoriesResponse(
             items = listOf(
-                SearchRepositoryResponse(
-                    fullName = "dtrupenn/Tetris",
-                    owner = Owner(avatarUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"),
-                    language = "Assembly",
-                    stargazersCount = 1,
-                    watchersCount = 1,
-                    forksCount = 0,
-                    openIssuesCount = 0,
-                ),
+                SearchRepositoryResponse.fake(),
             ),
         )
         val actual = repository.requestSearchRepositories(inputText = "inputText")

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
@@ -19,15 +19,7 @@ class RepositoryDetailScreenTest {
     fun `ownerIconUrl や language に何か設定されていれば表示されること`() {
         rule.setContent {
             RepositoryDetailScreen(
-                item = RepositoryItem(
-                    name = "dtrupenn/Tetris",
-                    ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                    language = "Assembly",
-                    stargazersCount = 1,
-                    watchersCount = 1,
-                    forksCount = 0,
-                    openIssuesCount = 0,
-                ),
+                item = RepositoryItem.fake(),
                 onCloseButtonClick = {},
             )
         }
@@ -40,15 +32,7 @@ class RepositoryDetailScreenTest {
     fun `language に何も設定されていなければ、言語自体表示されないこと`() {
         rule.setContent {
             RepositoryDetailScreen(
-                item = RepositoryItem(
-                    name = "dtrupenn/Tetris",
-                    ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                    language = null,
-                    stargazersCount = 1,
-                    watchersCount = 1,
-                    forksCount = 0,
-                    openIssuesCount = 0,
-                ),
+                item = RepositoryItem.fake(),
                 onCloseButtonClick = {},
             )
         }

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
@@ -33,7 +33,7 @@ class RepositoryDetailScreenTest {
     fun `language に何も設定されていなければ、言語自体表示されないこと`() {
         rule.setContent {
             RepositoryDetailScreen(
-                item = RepositoryItem.fake(),
+                item = RepositoryItem.fake().copy(language = null),
                 onCloseButtonClick = {},
                 onShowDetailButtonClick = {},
             )

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreenTest.kt
@@ -21,6 +21,7 @@ class RepositoryDetailScreenTest {
             RepositoryDetailScreen(
                 item = RepositoryItem.fake(),
                 onCloseButtonClick = {},
+                onShowDetailButtonClick = {},
             )
         }
 
@@ -34,6 +35,7 @@ class RepositoryDetailScreenTest {
             RepositoryDetailScreen(
                 item = RepositoryItem.fake(),
                 onCloseButtonClick = {},
+                onShowDetailButtonClick = {},
             )
         }
 

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchViewModelTest.kt
@@ -1,10 +1,10 @@
 package jp.co.yumemi.android.code_check.ui.search
 
 import app.cash.turbine.test
-import jp.co.yumemi.android.code_check.data.model.Owner
 import jp.co.yumemi.android.code_check.data.model.RepositoryItem
 import jp.co.yumemi.android.code_check.data.model.SearchRepositoriesResponse
 import jp.co.yumemi.android.code_check.data.model.SearchRepositoryResponse
+import jp.co.yumemi.android.code_check.data.model.fake
 import jp.co.yumemi.android.code_check.data.repository.SearchRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -25,15 +25,7 @@ class RepositorySearchViewModelTest {
     fun `APIから正常なデータが返ってきた場合、repositoryItems にそのデータが返ってくること`() = runTest {
         val searchRepositoriesResponse = SearchRepositoriesResponse(
             items = listOf(
-                SearchRepositoryResponse(
-                    fullName = "dtrupenn/Tetris",
-                    owner = Owner(avatarUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"),
-                    language = "Assembly",
-                    stargazersCount = 1,
-                    watchersCount = 1,
-                    forksCount = 0,
-                    openIssuesCount = 0,
-                ),
+                SearchRepositoryResponse.fake(),
             ),
         )
         whenever(searchRepository.requestSearchRepositories(any())).thenReturn(searchRepositoriesResponse)
@@ -42,15 +34,7 @@ class RepositorySearchViewModelTest {
 
         viewModel.repositoryItems.test {
             val expected = listOf(
-                RepositoryItem(
-                    name = "dtrupenn/Tetris",
-                    ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
-                    language = "Assembly",
-                    stargazersCount = 1,
-                    watchersCount = 1,
-                    forksCount = 0,
-                    openIssuesCount = 0,
-                ),
+                RepositoryItem.fake(),
             )
             assertEquals(expected, awaitItem())
         }


### PR DESCRIPTION
## Issue
- #9 

## 概要（必須）
- 詳細画面にて、[Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs/guide-get-started?hl=ja) を使ってリポジトリの詳細を表示できるようにした。

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="" width="300" > | <video src="https://github.com/user-attachments/assets/5743f519-b431-4ca2-90dc-e3aebed9fe89" width="300" >