### PR TITLE
読み込み失敗の表示を追加

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -60,10 +60,7 @@ fun RepositoryDetailScreen(
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OwnerIcon(
-                ownerIconUrl = item.ownerIconUrl,
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            )
+            OwnerIcon(ownerIconUrl = item.ownerIconUrl)
             item.language?.let { language ->
                 Text(
                     text = stringResource(R.string.written_language, language),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -60,7 +60,10 @@ fun RepositoryDetailScreen(
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OwnerIcon(ownerIconUrl = item.ownerIconUrl)
+            OwnerIcon(
+                ownerIconUrl = item.ownerIconUrl,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
             item.language?.let { language ->
                 Text(
                     text = stringResource(R.string.written_language, language),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
@@ -220,6 +220,7 @@ private class DataLoadingStateProvider : PreviewParameterProvider<DataLoadingSta
             DataLoadingState.Initial,
             DataLoadingState.InProgress,
             DataLoadingState.Success,
+            DataLoadingState.Failure(throwable = UnknownHostException()),
             DataLoadingState.Failure(throwable = Throwable()),
         )
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreen.kt
@@ -46,6 +46,7 @@ import jp.co.yumemi.android.code_check.data.model.DataLoadingState
 import jp.co.yumemi.android.code_check.data.model.RepositoryItem
 import jp.co.yumemi.android.code_check.ui.common.OwnerIcon
 import jp.co.yumemi.android.code_check.ui.theme.MainTheme
+import java.net.UnknownHostException
 
 @Composable
 fun RepositorySearchScreen(
@@ -78,6 +79,10 @@ fun RepositorySearchScreen(
             }
 
             is DataLoadingState.Failure -> {
+                FailureView(
+                    modifier = Modifier.padding(it),
+                    throwable = uiState.dataLoadingState.throwable,
+                )
             }
         }
     }
@@ -134,7 +139,7 @@ private fun InProgressView(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxSize()
-            .testTag("InProgressView")
+            .testTag("InProgressView"),
     ) {
         CircularProgressIndicator(
             modifier = Modifier
@@ -186,6 +191,26 @@ private fun SuccessView(
             }
             HorizontalDivider()
         }
+    }
+}
+
+@Composable
+private fun FailureView(
+    modifier: Modifier = Modifier,
+    throwable: Throwable,
+) {
+    val stringResId = when (throwable) {
+        // 例外の種類によってメッセージを切り替える
+        is UnknownHostException -> R.string.network_error_text
+        else -> R.string.other_error_text
+    }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(all = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = stringResource(id = stringResId))
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="forks_count">%d forks</string>
     <string name="open_issues_count">%d open issues</string>
     <string name="show_detail_button_label">Show Detail</string>
+
+    <!-- error -->
+    <string name="network_error_text">検索に失敗しました。ネットワークに接続されているか確認し、しばらく待ってから再度お試しください。</string>
+    <string name="other_error_text">検索に失敗しました。障害が発生している可能性があるため、開発者にお問い合わせください。</string>
 </resources>

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreenTest.kt
@@ -132,4 +132,19 @@ class RepositorySearchScreenTest {
 
         rule.onNodeWithText("検索に失敗しました。ネットワークに接続されているか確認し、しばらく待ってから再度お試しください。").assertIsDisplayed()
     }
+
+    @Test
+    fun `データ読み込み失敗時にUnknownHostException以外の例外が発生したら、障害が発生している旨が表示されること`() {
+        rule.setContent {
+            RepositorySearchScreen(
+                uiState = RepositorySearchUiState(
+                    dataLoadingState = DataLoadingState.Failure(throwable = Throwable()),
+                ),
+                onSearchButtonClick = {},
+                onItemClick = {},
+            )
+        }
+
+        rule.onNodeWithText("検索に失敗しました。障害が発生している可能性があるため、開発者にお問い合わせください。").assertIsDisplayed()
+    }
 }

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositorySearchScreenTest.kt
@@ -14,6 +14,7 @@ import jp.co.yumemi.android.code_check.data.model.RepositoryItem
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.net.UnknownHostException
 import kotlin.test.Test
 
 @Suppress("NonAsciiCharacters", "TestFunctionName")
@@ -115,5 +116,20 @@ class RepositorySearchScreenTest {
         rule.onNodeWithText("dtrupenn/Tetris").assertIsDisplayed()
         rule.onNodeWithTag("language").assertDoesNotExist()
         rule.onNodeWithText("1 stars").assertIsDisplayed()
+    }
+
+    @Test
+    fun `データ読み込み失敗時にUnknownHostExceptionが発生したら、ネットワークエラーの旨が表示されること`() {
+        rule.setContent {
+            RepositorySearchScreen(
+                uiState = RepositorySearchUiState(
+                    dataLoadingState = DataLoadingState.Failure(throwable = UnknownHostException()),
+                ),
+                onSearchButtonClick = {},
+                onItemClick = {},
+            )
+        }
+
+        rule.onNodeWithText("検索に失敗しました。ネットワークに接続されているか確認し、しばらく待ってから再度お試しください。").assertIsDisplayed()
     }
 }


### PR DESCRIPTION
## Issue
- #9 

## 概要（必須）
- UX 向上のため、読み込み失敗時はエラーメッセージを表示するようにした。

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/76d79d3e-4a90-466c-9b89-2a3c21b8fabf" width="300" > | <video src="https://github.com/user-attachments/assets/1d4804aa-8698-45e3-8e3e-310301f2613f" width="300" >