### PR TITLE
RepositoryDetailScreen の UI 調整

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -60,7 +60,10 @@ fun RepositoryDetailScreen(
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            OwnerIcon(ownerIconUrl = item.ownerIconUrl)
+            OwnerIcon(
+                ownerIconUrl = item.ownerIconUrl,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
             item.language?.let { language ->
                 Text(
                     text = stringResource(R.string.written_language, language),

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,7 +44,6 @@ fun RepositoryDetailScreen(
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Close,
-                            tint = Color.Black,
                             contentDescription = null,
                         )
                     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/RepositoryDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.co.yumemi.android.code_check.R
@@ -37,7 +38,13 @@ fun RepositoryDetailScreen(
         modifier = modifier,
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(text = item.name) },
+                title = {
+                    Text(
+                        text = item.name,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                    )
+                },
                 navigationIcon = {
                     IconButton(
                         onClick = onCloseButtonClick,

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.AndroidEngineerCodeCheck" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.AndroidEngineerCodeCheck" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,11 +14,4 @@
         <!-- Customize your theme here. -->
     </style>
 
-    <style name="TextInputLayoutNoBorder" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
-        <item name="errorIconDrawable">@null</item>
-        <item name="errorIconTint">@null</item>
-        <item name="hintEnabled">false</item>
-        <item name="boxBackgroundMode">none</item>
-    </style>
-
 </resources>


### PR DESCRIPTION
## Issue
- #8 

## 概要（必須）
- RepositoryDetailScreen にて以下の問題があったので対応する。
  - 画像の中央揃え対応
  - ダークモード対応
  - TopAppBar のタイトル表示が必ず1行になるよう修正

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/1061c85e-fd13-4739-9ed1-8c16c31d1724" width="300" /> | <img src="https://github.com/user-attachments/assets/14b50bbe-3996-4c40-a0cd-4c05b02c0186" width="300" />
<img src="https://github.com/user-attachments/assets/1b4b431c-cc67-45d5-ac37-48168b9c9946" width="300" /> | <img src="https://github.com/user-attachments/assets/55aaa3e1-89c6-4496-a98c-258bfe66be24" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
