### PR TITLE
詳細画面にて、画面回転をした際に表示要素が隠れ、スクロールができないために表示させられない点があったのを修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/detail/RepositoryDetailScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
@@ -62,7 +64,8 @@ fun RepositoryDetailScreen(
             modifier = Modifier
                 .padding(it)
                 .padding(horizontal = 8.dp)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .verticalScroll(state = rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             OwnerIcon(

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreen.kt
@@ -64,29 +64,27 @@ fun RepositorySearchScreen(
         topBar = {
             SearchTextField(onSearchButtonClick = onSearchButtonClick)
         },
-    ) {
-        when (uiState.dataLoadingState) {
-            is DataLoadingState.Initial -> {
-                InitialView(modifier = Modifier.padding(it))
-            }
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            when (uiState.dataLoadingState) {
+                is DataLoadingState.Initial -> {
+                    InitialView()
+                }
 
-            is DataLoadingState.InProgress -> {
-                InProgressView(modifier = Modifier.padding(it))
-            }
+                is DataLoadingState.InProgress -> {
+                    InProgressView()
+                }
 
-            is DataLoadingState.Success -> {
-                SuccessView(
-                    repositoryItems = uiState.repositoryItems,
-                    modifier = Modifier.padding(it),
-                    onItemClick = onItemClick,
-                )
-            }
+                is DataLoadingState.Success -> {
+                    SuccessView(
+                        repositoryItems = uiState.repositoryItems,
+                        onItemClick = onItemClick,
+                    )
+                }
 
-            is DataLoadingState.Failure -> {
-                FailureView(
-                    modifier = Modifier.padding(it),
-                    throwable = uiState.dataLoadingState.throwable,
-                )
+                is DataLoadingState.Failure -> {
+                    FailureView(throwable = uiState.dataLoadingState.throwable)
+                }
             }
         }
     }

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/detail/RepositoryDetailScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/detail/RepositoryDetailScreenTest.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.codecheck.ui.detail
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -26,7 +25,7 @@ class RepositoryDetailScreenTest {
             )
         }
 
-        rule.onNodeWithContentDescription("OwnerIcon").assertIsDisplayed()
+        rule.onNodeWithContentDescription("OwnerIcon").assertExists()
         rule.onNodeWithTag("language").assertExists()
     }
 
@@ -40,7 +39,7 @@ class RepositoryDetailScreenTest {
             )
         }
 
-        rule.onNodeWithContentDescription("OwnerIcon").assertIsDisplayed()
+        rule.onNodeWithContentDescription("OwnerIcon").assertExists()
         rule.onNodeWithTag("language").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## Issue
- #34 

## 概要（必須）
- 詳細画面にて、画面回転をした際に表示要素が隠れ、スクロールができないために表示させられない点があったのを修正した
- 検索画面のリスト上部に不自然な空白があったのを修正した

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/6ddbe908-9393-43c0-92ef-8b232705382d" width="300" /> | <img src="https://github.com/user-attachments/assets/849c56fd-3a80-4c36-9a78-7da6c0ca0ce0" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/52e81f63-7482-497b-a882-d172ae2d7d2d" width="300" > | <video src="https://github.com/user-attachments/assets/b74eca6d-7973-4bbf-bdab-5873e9b1649f" width="300" >
