### PR TITLE
SearchRepositoriesResponse や Throwable (UnknownHostException) などの通信周りの知識を ui 側が持たなくてもいいようにする

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/DataLoadingState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/DataLoadingState.kt
@@ -3,16 +3,16 @@ package jp.co.yumemi.android.codecheck.data.model
 /**
  * データの読み込み状態を表す
  */
-sealed class DataLoadingState {
+sealed interface DataLoadingState {
     /** 初回表示時 */
-    data object Initial : DataLoadingState()
+    data object Initial : DataLoadingState
 
     /** 読み込み中 */
-    data object InProgress : DataLoadingState()
+    data object InProgress : DataLoadingState
 
     /** 読み込み成功 */
-    data object Success : DataLoadingState()
+    data object Success : DataLoadingState
 
     /** 読み込み失敗 */
-    data class Failure(val errorType: ErrorType) : DataLoadingState()
+    data class Failure(val errorType: ErrorType) : DataLoadingState
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/DataLoadingState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/DataLoadingState.kt
@@ -14,5 +14,5 @@ sealed class DataLoadingState {
     data object Success : DataLoadingState()
 
     /** 読み込み失敗 */
-    data class Failure(val throwable: Throwable) : DataLoadingState()
+    data class Failure(val errorType: ErrorType) : DataLoadingState()
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorType.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorType.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.android.codecheck.data.model
+
+enum class ErrorType {
+    NETWORK_ERROR,
+    OTHER_ERROR
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorType.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorType.kt
@@ -1,6 +1,15 @@
 package jp.co.yumemi.android.codecheck.data.model
 
+import java.net.UnknownHostException
+
 enum class ErrorType {
     NETWORK_ERROR,
-    OTHER_ERROR
+    OTHER_ERROR;
+
+    companion object {
+        fun from(throwable: Throwable) = when (throwable) {
+            is UnknownHostException -> NETWORK_ERROR
+            else -> OTHER_ERROR
+        }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/SearchRepositoriesResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/model/SearchRepositoriesResponse.kt
@@ -27,16 +27,3 @@ data class SearchRepositoryResponse(
 data class Owner(
     @SerialName("avatar_url") val avatarUrl: String,
 )
-
-fun SearchRepositoryResponse.Companion.fake(): SearchRepositoryResponse {
-    return SearchRepositoryResponse(
-        fullName = "dtrupenn/Tetris",
-        owner = Owner(avatarUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"),
-        htmlUrl = "https://github.com/dtrupenn/Tetris",
-        language = "Assembly",
-        stargazersCount = 1,
-        watchersCount = 1,
-        forksCount = 0,
-        openIssuesCount = 0,
-    )
-}

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/data/repository/SearchRepository.kt
@@ -5,16 +5,19 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
+import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
 import jp.co.yumemi.android.codecheck.data.model.SearchRepositoriesResponse
+import jp.co.yumemi.android.codecheck.data.model.toRepositoryItem
 import javax.inject.Inject
 
 class SearchRepository @Inject constructor(
     private val client: HttpClient,
 ) {
-    suspend fun requestSearchRepositories(inputText: String): SearchRepositoriesResponse {
+    suspend fun requestSearchRepositories(inputText: String): List<RepositoryItem> {
         val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
             parameter("q", inputText)
         }
-        return response.body<SearchRepositoriesResponse>()
+        val searchRepositoriesResponse = response.body<SearchRepositoriesResponse>()
+        return searchRepositoriesResponse.items.map { it.toRepositoryItem() }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreen.kt
@@ -46,11 +46,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import jp.co.yumemi.android.codecheck.R
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
+import jp.co.yumemi.android.codecheck.data.model.ErrorType
 import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
 import jp.co.yumemi.android.codecheck.ui.common.OwnerIcon
 import jp.co.yumemi.android.codecheck.ui.theme.MainTheme
 import kotlinx.coroutines.coroutineScope
-import java.net.UnknownHostException
 
 @Composable
 fun RepositorySearchScreen(
@@ -83,7 +83,7 @@ fun RepositorySearchScreen(
                 }
 
                 is DataLoadingState.Failure -> {
-                    FailureView(throwable = uiState.dataLoadingState.throwable)
+                    FailureView(errorType = uiState.dataLoadingState.errorType)
                 }
             }
         }
@@ -199,11 +199,11 @@ private fun SuccessView(
 @Composable
 private fun FailureView(
     modifier: Modifier = Modifier,
-    throwable: Throwable,
+    errorType: ErrorType,
 ) {
-    val stringResId = when (throwable) {
+    val stringResId = when (errorType) {
         // 例外の種類によってメッセージを切り替える
-        is UnknownHostException -> R.string.network_error_text
+        ErrorType.NETWORK_ERROR -> R.string.network_error_text
         else -> R.string.other_error_text
     }
     Box(
@@ -246,8 +246,8 @@ private class DataLoadingStateProvider : PreviewParameterProvider<DataLoadingSta
             DataLoadingState.Initial,
             DataLoadingState.InProgress,
             DataLoadingState.Success,
-            DataLoadingState.Failure(throwable = UnknownHostException()),
-            DataLoadingState.Failure(throwable = Throwable()),
+            DataLoadingState.Failure(errorType = ErrorType.NETWORK_ERROR),
+            DataLoadingState.Failure(errorType = ErrorType.OTHER_ERROR),
         )
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
+import jp.co.yumemi.android.codecheck.data.model.ErrorType
 import jp.co.yumemi.android.codecheck.data.model.toRepositoryItem
 import jp.co.yumemi.android.codecheck.data.repository.SearchRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +40,7 @@ class RepositorySearchViewModel @Inject constructor(
         } catch (throwable: Throwable) {
             Timber.e(throwable)
             _uiState.value = RepositorySearchUiState(
-                dataLoadingState = DataLoadingState.Failure(throwable = throwable),
+                dataLoadingState = DataLoadingState.Failure(errorType = ErrorType.from(throwable = throwable)),
                 repositoryItems = emptyList(),
             )
         }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
 import jp.co.yumemi.android.codecheck.data.model.ErrorType
-import jp.co.yumemi.android.codecheck.data.model.toRepositoryItem
 import jp.co.yumemi.android.codecheck.data.repository.SearchRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,10 +31,10 @@ class RepositorySearchViewModel @Inject constructor(
     fun searchRepositories(inputText: String) = viewModelScope.launch {
         try {
             _uiState.value = RepositorySearchUiState(dataLoadingState = DataLoadingState.InProgress)
-            val response = searchRepository.requestSearchRepositories(inputText = inputText)
+            val repositoryItems = searchRepository.requestSearchRepositories(inputText = inputText)
             _uiState.value = RepositorySearchUiState(
                 dataLoadingState = DataLoadingState.Success,
-                repositoryItems = response.items.map { it.toRepositoryItem() },
+                repositoryItems = repositoryItems,
             )
         } catch (throwable: Throwable) {
             Timber.e(throwable)

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorTypeTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/data/model/ErrorTypeTest.kt
@@ -1,0 +1,21 @@
+package jp.co.yumemi.android.codecheck.data.model
+
+import java.net.UnknownHostException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Suppress("NonAsciiCharacters")
+class ErrorTypeTest {
+
+    @Test
+    fun `UnknownHostException の場合、NETWORK_ERROR が返ってくること`() {
+        val throwable = UnknownHostException()
+        assertEquals(ErrorType.NETWORK_ERROR, ErrorType.from(throwable = throwable))
+    }
+
+    @Test
+    fun `その他の例外の場合、OTHER_ERROR が返ってくること`() {
+        val throwable = Throwable()
+        assertEquals(ErrorType.OTHER_ERROR, ErrorType.from(throwable = throwable))
+    }
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/data/repository/SearchRepositoryTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/data/repository/SearchRepositoryTest.kt
@@ -9,9 +9,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
-import jp.co.yumemi.android.codecheck.data.model.SearchRepositoriesResponse
-import jp.co.yumemi.android.codecheck.data.model.SearchRepositoryResponse
-import jp.co.yumemi.android.codecheck.data.model.fake
+import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.runner.RunWith
@@ -43,9 +41,16 @@ class SearchRepositoryTest {
             }
         }
         val repository = SearchRepository(client = client)
-        val expected = SearchRepositoriesResponse(
-            items = listOf(
-                SearchRepositoryResponse.fake(),
+        val expected = listOf(
+            RepositoryItem(
+                name = "dtrupenn/Tetris",
+                ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+                htmlUrl = "https://github.com/dtrupenn/Tetris",
+                language = "Assembly",
+                stargazersCount = 1,
+                watchersCount = 1,
+                forksCount = 0,
+                openIssuesCount = 0,
             ),
         )
         val actual = repository.requestSearchRepositories(inputText = "inputText")

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreenTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchScreenTest.kt
@@ -10,11 +10,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
+import jp.co.yumemi.android.codecheck.data.model.ErrorType
 import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.net.UnknownHostException
 import kotlin.test.Test
 
 @Suppress("NonAsciiCharacters", "TestFunctionName")
@@ -119,11 +119,11 @@ class RepositorySearchScreenTest {
     }
 
     @Test
-    fun `データ読み込み失敗時にUnknownHostExceptionが発生したら、ネットワークエラーの旨が表示されること`() {
+    fun `データ読み込み失敗時に NETWORK_ERROR だったら、ネットワークエラーの旨が表示されること`() {
         rule.setContent {
             RepositorySearchScreen(
                 uiState = RepositorySearchUiState(
-                    dataLoadingState = DataLoadingState.Failure(throwable = UnknownHostException()),
+                    dataLoadingState = DataLoadingState.Failure(errorType = ErrorType.NETWORK_ERROR),
                 ),
                 onSearchButtonClick = {},
                 onItemClick = {},
@@ -134,11 +134,11 @@ class RepositorySearchScreenTest {
     }
 
     @Test
-    fun `データ読み込み失敗時にUnknownHostException以外の例外が発生したら、障害が発生している旨が表示されること`() {
+    fun `データ読み込み失敗時に OTHER_ERROR だったら、障害が発生している旨が表示されること`() {
         rule.setContent {
             RepositorySearchScreen(
                 uiState = RepositorySearchUiState(
-                    dataLoadingState = DataLoadingState.Failure(throwable = Throwable()),
+                    dataLoadingState = DataLoadingState.Failure(errorType = ErrorType.OTHER_ERROR),
                 ),
                 onSearchButtonClick = {},
                 onItemClick = {},

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModelTest.kt
@@ -2,6 +2,7 @@ package jp.co.yumemi.android.codecheck.ui.search
 
 import app.cash.turbine.test
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
+import jp.co.yumemi.android.codecheck.data.model.ErrorType
 import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
 import jp.co.yumemi.android.codecheck.data.model.SearchRepositoriesResponse
 import jp.co.yumemi.android.codecheck.data.model.SearchRepositoryResponse
@@ -53,7 +54,7 @@ class RepositorySearchViewModelTest {
 
         viewModel.uiState.test {
             val expected = RepositorySearchUiState(
-                dataLoadingState = DataLoadingState.Failure(throwable = exception),
+                dataLoadingState = DataLoadingState.Failure(errorType = ErrorType.from(throwable = exception)),
                 repositoryItems = emptyList(),
             )
             assertEquals(expected, awaitItem())

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/search/RepositorySearchViewModelTest.kt
@@ -4,9 +4,6 @@ import app.cash.turbine.test
 import jp.co.yumemi.android.codecheck.data.model.DataLoadingState
 import jp.co.yumemi.android.codecheck.data.model.ErrorType
 import jp.co.yumemi.android.codecheck.data.model.RepositoryItem
-import jp.co.yumemi.android.codecheck.data.model.SearchRepositoriesResponse
-import jp.co.yumemi.android.codecheck.data.model.SearchRepositoryResponse
-import jp.co.yumemi.android.codecheck.data.model.fake
 import jp.co.yumemi.android.codecheck.data.repository.SearchRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -25,21 +22,27 @@ class RepositorySearchViewModelTest {
 
     @Test
     fun `APIから正常なデータが返ってきた場合、uiState にそのデータが返ってくること`() = runTest {
-        val searchRepositoriesResponse = SearchRepositoriesResponse(
-            items = listOf(
-                SearchRepositoryResponse.fake(),
+        val inputText = "テスト"
+        val repositoryItems = listOf(
+            RepositoryItem(
+                name = "dtrupenn/Tetris",
+                ownerIconUrl = "https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+                htmlUrl = "https://github.com/dtrupenn/Tetris",
+                language = "Assembly",
+                stargazersCount = 1,
+                watchersCount = 1,
+                forksCount = 0,
+                openIssuesCount = 0,
             ),
         )
-        whenever(searchRepository.requestSearchRepositories(any())).thenReturn(searchRepositoriesResponse)
+        whenever(searchRepository.requestSearchRepositories(inputText)).thenReturn(repositoryItems)
 
-        viewModel.searchRepositories(inputText = "テスト")
+        viewModel.searchRepositories(inputText = inputText)
 
         viewModel.uiState.test {
             val expected = RepositorySearchUiState(
                 dataLoadingState = DataLoadingState.Success,
-                repositoryItems = listOf(
-                    RepositoryItem.fake(),
-                ),
+                repositoryItems = repositoryItems,
             )
             assertEquals(expected, awaitItem())
         }


### PR DESCRIPTION
## Issue
- #34 

## 概要（必須）
- SearchRepositoriesResponse や Throwable (UnknownHostException) などの通信周りの知識を ui 側が持たなくてもいいようにする
  - Repository 時点で RepositoryItem に変換するようにした
  - アプリ独自のエラーとして、ErrorType を定義した

## リンク
- 

## スクリーンショット（スクリーンショットのテストがある場合、またはUIと無関係な場合は任意）
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## 動画（任意）
Before | After
:--: | :--:
<video src="" width="300" > | <video src="" width="300" >
